### PR TITLE
fix package.json to point to lib entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "node-tmdb",
+    "main": "lib/tmdb.js",
     "version": "0.1.0",
     "description": "Implementation of TMDb's v3 API",
     "author": "Mikael Emilsson <mikael.emilsson@gmail.com>",


### PR DESCRIPTION
when linking npm against your lib, require failed if package.json was missing main entry.
