### PR TITLE
Added support for appending responses to the movie.info query

### DIFF
--- a/lib/tmdb.js
+++ b/lib/tmdb.js
@@ -154,10 +154,16 @@ tmdb.prototype.configuration = function(callback) {
 /**
  * movie methods
  * q = id (can be either tmdb id or imdb id)
+ * append_to_response = include one or more of the other queries (info only)
  **/
 tmdb.prototype.movie = {
-    info: function(q, callback) {
+    info: function(q, append_to_response, callback) {
+        if (typeof append_to_response === "function") {
+            callback = append_to_response;
+            append_to_response = undefined;
+        }
         var url = me.api_urls.movie_info.format(q);
+        if (append_to_response) url = url + "&append_to_response=" + append_to_response;
         executeQuery({url:url}, callback);
     },
     alternativeTitles: function(q, callback) {


### PR DESCRIPTION
Hi raqqa,

thanks for the great package. I added a quick change that allows the inclusion of other queries in the movie.info query, as specified in the APIv3 using the append_to_response parameter.

Cheers,
  Jonathan